### PR TITLE
Change to use non-proprietary fiber file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ build/*
 # Setup tools directories
 pyNLO.egg-info/*
 src/pyNLO.egg-info/*
+dist/*

--- a/src/pynlo/media/fibers/fiber.py
+++ b/src/pynlo/media/fibers/fiber.py
@@ -57,7 +57,7 @@ class FiberInstance:
         self.c_mks = constants.speed_of_light
         self.c = constants.speed_of_light * 1e9/1e12 # c in nm/ps
         self.is_simple_fiber = False
-        self.fiberloader = JSONFiberLoader.JSONFiberLoader('nist_fibers')
+        self.fiberloader = JSONFiberLoader.JSONFiberLoader('general_fibers')
         self.dispersion_changes_with_z = False
         
         


### PR DESCRIPTION
Proprietary fiber file has been moved onto o:\Public\pyNLOFibers.