### PR TITLE
Improvements to the readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,12 @@ build/*
 pyNLO.egg-info/*
 src/pyNLO.egg-info/*
 dist/*
+
+# we should generally ignore images, pdf files, etc. in case those get in somehow:
+*.png
+*.jpg
+*.jpeg
+*.tif
+*.tiff
+*.pdf
+*.doc

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,86 @@
-pyNLO: Nonlinear optics modeling codes for Python
-=================================================
+pyNLO: Nonlinear optics modeling for Python
+===========================================
 
-Scientific codes for optical physics. 
+Documentation is available at http://pynlo.readthedocs.org/
 
-Documentation is available at http://pynlo.readthedocs.org/en/latest/
+.. image:: https://cloud.githubusercontent.com/assets/1107796/13850062/17f09ea8-ec1e-11e5-9311-b94df29c01cb.png
+   :width: 330px
+   :alt: PyNLO
+   :align: right
+
+
+Introduction
+------------
+
+PyNLO provides an easy-to-use, object-oriented set of tools for modeling the nonlinear interaction of light with materials. It provides many functionalities for representing pulses of light, beams of light, and nonlinear materials, such as crystals and fibers. Also, it features methods for simulating both three-wave-mixing processes (such as DFG), as well as four-wave-mixing processes such as supercontinuum generation. 
+
+Features:
+	- A solver for the propagation of light through a Chi-3 material, useful for simulation pulse compression and supercontinuum generation in an optical fiber. This solver is highly efficient, thanks to an adaptive-step-size implementation of the "Fourth-order Runge-Kutta in the Interaction Picture " (RK4IP) method of `Hult (2007) <https://www.osapublishing.org/jlt/abstract.cfm?uri=jlt-25-12-3770>`_.
+	
+	- A solver for difference frequency generation. 
+	
+	- ...and much more!
+
+
+
+Installation
+------------
+
+PyNLO requires Python 2.7 or 3.3-3.5. If you don't already have Python, we recommend an "all in one" Python package such as the `Anaconda Python Distribution <https://www.continuum.io/downloads>`_, which is available for free.
+
+With pip
+~~~~~~~~
+
+The latest release can be installed from PyPi with ::
+
+    pip install pynlo
+
+With setuptools
+~~~~~~~~~~~~~~~
+
+If you prefer the development version from GitHub, download it here, `cd` to the PyNLO directory, and use ::
+
+    python setup.py install
+
+Or, if you wish to edit the PyNLO source code without re-installing each time ::
+
+    python setup.py develop
+
+
+Example of use
+--------------
+
+Simple example goes here:
+
+.. code-block:: python
+
+	import pynlo
+	
+	pynlo......
+	
+
+Documentation
+-------------
+The complete documentation for PyNLO is availabe at https://pynlo.readthedocs.org.
+
+
+Contributing
+------------
+
+We welcome suggestions for improvement! The best way to to open a new issue here: https://github.com/pyNLO/PyNLO/issues/.
+
+
+License
+-------
+PyNLO is licensed under the `GPLv3 license <http://choosealicense.com/licenses/gpl-3.0/>`_. This means that you are free to use PyNLO for any **open-source** project. Of course, PyNLO is provided "as is" with absolutely no warrenty.
+
+
+References
+--------
+[1] Johan Hult, "A Fourth-Order Runge–Kutta in the Interaction Picture Method for Simulating Supercontinuum Generation in Optical Fibers," J. Lightwave Technol. 25, 3770-3775 (2007) https://www.osapublishing.org/jlt/abstract.cfm?uri=jlt-25-12-3770
+
+
+
+
+
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,7 @@ extensions = [
     'sphinx.ext.autodoc',
 	'sphinx.ext.napoleon',
     'sphinx.ext.doctest',
-    'sphinx.ext.intersphinx',
+    # 'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.coverage',
     'sphinx.ext.mathjax',

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ Contents:
 .. toctree::
    :maxdepth: 2
    
+   readme_link
    general
    pynlo
    examples

--- a/docs/source/readme_link.rst
+++ b/docs/source/readme_link.rst
@@ -1,0 +1,1 @@
+.. include:: ../../README.rst


### PR DESCRIPTION
I added a bunch of text to the readme to give people a bit more information about what PyNLO can do and how to install it. I basically just copied this from another project (PyAbel), so hopefully it sounds okay. Feel free to change it as you wish (or tell me to change it). 

Additionally, I built the readme as part of the docs. This way, we can put a lot of the general information in the readme and it will also appear in the docs, saving us the trouble of re-typing all of this general information into another place in the docs. I think this is a good way to do it, because it synchronizes all of the general info between rtfd.org, pypi, and github. 

Also, I removed sphinx.ext.intersphinx from the conf.py. Intersphinx is used for references to other docs outside of PyNLO. Do we need this? It makes the doc build stall for a long time if you have a bad internet connection, so if we can avoid using it, then this would be nice. You can always just put in a static http link in the docs if you want to refer to things elsewhere on the interwebs. 