### PR TITLE
Option to disable raman

### DIFF
--- a/src/pynlo/interactions/FourWaveMixing/SSFM.py
+++ b/src/pynlo/interactions/FourWaveMixing/SSFM.py
@@ -191,35 +191,35 @@ class SSFM:
 
         self.last_h    =  None      
 
-        if not self.disable_Raman:
-            
-            self.CalculateRamanResponseFT(pulse_in)
-            
-            if raman_plots:
-                plt.subplot(221)
-                plt.plot(self.omegas/(2*np.pi), np.abs(self.R - (1-self.f_R)),'bo')                
-                plt.plot(self.omegas/(2*np.pi), np.abs(self.R0 - (1-self.f_R0)),'r')
-                #plt.xlim([0,25])
-                plt.title('Abs[R(w)]')
-                plt.xlabel('THz')                
-                plt.subplot(222)
-                plt.plot(self.omegas/(2*np.pi), np.unwrap(np.angle(self.R-(1-self.f_R))),'bo')
-                plt.plot(self.omegas/(2*np.pi), np.unwrap(np.angle(self.R0-(1-self.f_R0))),'r')                
-                plt.title('Angle[R(w)]')
-                plt.xlabel('THz')
-                plt.subplot(223)
-                plt.plot(pulse_in.T*1000, ifftshift(np.real(self.IFFT_t(\
-                        self.R - (1-self.f_R)))), 'bo')
-                plt.plot(pulse_in.T*1000, ifftshift(np.real(self.IFFT_t(\
-                        self.R0 - (1-self.f_R0)))), 'r')  
-                plt.title('Abs[R[t]]')
-                plt.xlim([0,1000])
-                plt.xlabel('fs')
-                plt.subplot(224)
-                plt.plot(self.omegas/(2*np.pi), abs(self.FFT_t(self.A)))
-                plt.title('Abs[A[w]]')
-                plt.xlabel('THz')
-                plt.show()
+        # if not self.disable_Raman:
+        
+        self.CalculateRamanResponseFT(pulse_in)
+
+        if raman_plots:
+            plt.subplot(221)
+            plt.plot(self.omegas/(2*np.pi), np.abs(self.R - (1-self.f_R)),'bo')
+            plt.plot(self.omegas/(2*np.pi), np.abs(self.R0 - (1-self.f_R0)),'r')
+            #plt.xlim([0,25])
+            plt.title('Abs[R(w)]')
+            plt.xlabel('THz')
+            plt.subplot(222)
+            plt.plot(self.omegas/(2*np.pi), np.unwrap(np.angle(self.R-(1-self.f_R))),'bo')
+            plt.plot(self.omegas/(2*np.pi), np.unwrap(np.angle(self.R0-(1-self.f_R0))),'r')
+            plt.title('Angle[R(w)]')
+            plt.xlabel('THz')
+            plt.subplot(223)
+            plt.plot(pulse_in.T*1000, ifftshift(np.real(self.IFFT_t(\
+                    self.R - (1-self.f_R)))), 'bo')
+            plt.plot(pulse_in.T*1000, ifftshift(np.real(self.IFFT_t(\
+                    self.R0 - (1-self.f_R0)))), 'r')
+            plt.title('Abs[R[t]]')
+            plt.xlim([0,1000])
+            plt.xlabel('fs')
+            plt.subplot(224)
+            plt.plot(self.omegas/(2*np.pi), abs(self.FFT_t(self.A)))
+            plt.title('Abs[A[w]]')
+            plt.xlabel('THz')
+            plt.show()
                 
         # Load up parameters
         self.A[:]       = self.conditional_fftshift(pulse_in.AT, verify=True)
@@ -244,6 +244,10 @@ class SSFM:
         as is the factor of pulse_width.
         """
         
+        if self.disable_Raman:
+            self.R[:]=1
+            return
+
         # Laserfoam raman function.
         TAU1 = self.tau_1
         TAU2 = self.tau_2
@@ -393,30 +397,35 @@ class SSFM:
         return self.IFFT_t(-1.0j*self.omegas * Aw)
 
     def NonlinearOperator(self,A):
-        if self.disable_Raman:
-            if self.disable_self_steepening:
-                return 1j*self.gamma*np.abs(A)**2
-                
-            self.Aw[:] = self.FFT_t(A)
-            self.dA[:] = self.Deriv(A)
-            
-            return 1j*self.gamma*np.abs(A)**2 - \
-                   (self.gamma/self.w0)*(2.0*self.dA*A.conj() + A*self.dA.conj())
+        # DH commented this out on 2016-03-18
+        # it should be taken care of by setting
+        # self.R[:]=0 in CalculateRamanResponseFT
+        # if self.disable_Raman:
+ #            if self.disable_self_steepening:
+ #                return 1j*self.gamma*np.abs(A)**2
+ #
+ #            self.Aw[:] = self.FFT_t(A)
+ #            self.dA[:] = self.Deriv(A)
+ #
+ #            return 1j*self.gamma*np.abs(A)**2 - \
+ #                   (self.gamma/self.w0)*(2.0*self.dA*A.conj() + A*self.dA.conj())
+ #
+ #
+ #        else:
+        self.A2[:]  = np.abs(A)**2   
+        self.A2w[:] = self.FFT_t(self.A2)
+   
+        if self.disable_self_steepening:
+            return 1j*self.gamma*self.IFFT_t(self.R*self.A2w)
         else:
-            self.A2[:]  = np.abs(A)**2   
-            self.A2w[:] = self.FFT_t(self.A2)
-           
-            if self.disable_self_steepening:
-                return 1j*self.gamma*self.IFFT_t(self.R*self.A2w)
-            else:
-                self.Aw[:]      = self.FFT_t(A)
-                self.R_A2[:]    = self.IFFT_t(self.R*self.A2w)
-                self.dA[:]      = self.Deriv(self.Aw)
-                self.dA2[:]     = self.Deriv(self.A2w)
-                self.dR_A2[:]   = self.IFFT_t(self.R*self.FFT_t(self.dA2))
-                
-                return 1j*self.gamma*self.R_A2 - (self.gamma/self.w0)* \
-                       (self.dR_A2 + np.where(np.abs(A)>1.0E-15,self.dA*self.R_A2/(1.0e-20+A),0.0))
+            self.Aw[:]      = self.FFT_t(A)
+            self.R_A2[:]    = self.IFFT_t(self.R*self.A2w)
+            self.dA[:]      = self.Deriv(self.Aw)
+            self.dA2[:]     = self.Deriv(self.A2w)
+            self.dR_A2[:]   = self.IFFT_t(self.R*self.FFT_t(self.dA2))
+        
+            return 1j*self.gamma*self.R_A2 - (self.gamma/self.w0)* \
+                   (self.dR_A2 + np.where(np.abs(A)>1.0E-15,self.dA*self.R_A2/(1.0e-20+A),0.0))
 
 
     def RK4IP(self,A,h,direction):


### PR DESCRIPTION
As discussed in https://github.com/pyNLO/PyNLO/issues/20, I changed the "disable raman" to work by setting the raman gain to zero instead of using separate code. This allows the Raman contribution to be disabled while still keeping the self-steepening. Previously, this was not possible. 

I commented out some code that is no longer needed, but if we are confident about this change, then it should simply be deleted.