### PR TITLE
Fix noise calculation in PulseBase.py

### DIFF
--- a/src/examples/SSFM_coherence.py
+++ b/src/examples/SSFM_coherence.py
@@ -27,6 +27,10 @@ Steep   = True    # Enable self steepening?
 
 alpha = np.log((10**(Alpha * 0.1))) * 100  # convert from dB/cm to 1/m
 
+# select a method for include noise on the input pulse:
+# noise_type = 'sqrt_N_freq'
+noise_type = 'one_photon_freq'
+
 
 # DRAFT - use these parameters for a quick calculation
 trials  = 2
@@ -89,7 +93,7 @@ pulse = pynlo.light.DerivedPulses.SechPulse(power = 1, # Power will be scaled by
 pulse.set_epp(EPP) # set the pulse energy
 
 g12, results = evol.calculate_coherence(pulse_in=pulse, fiber=fiber1, n_steps=Steps,
-                                        num_trials=trials)
+                                        num_trials=trials, noise_type=noise_type)
 
 def dB(num):
     return 10 * np.log10(np.abs(num)**2)
@@ -104,7 +108,7 @@ for y, AW, AT, pulse_in, pulse_out in results:
 
     zT = dB( np.transpose(AT) )
     ax4.plot(pulse_out.T_ps,     dB(pulse_out.AT),  color = 'r')
-    ax4.plot(pulse.T_ps,     dB(pulse.AT),  color = 'b')
+    ax4.plot(pulse.T_ps,         dB(    pulse.AT),  color = 'b')
 
 
 g12 = g12.transpose()

--- a/src/examples/SSFM_coherence.py
+++ b/src/examples/SSFM_coherence.py
@@ -56,7 +56,7 @@ EPP     = 180e-12 # Energy per pulse (J)
 
 
 # set up plots for the results:
-fig = plt.figure(figsize=(13,10))
+fig = plt.figure(figsize=(11,8))
 ax0 = plt.subplot2grid((3,3), (0, 0), rowspan=1)
 ax1 = plt.subplot2grid((3,3), (1, 0), rowspan=2, sharex=ax0)
 
@@ -94,11 +94,11 @@ g12, results = evol.calculate_coherence(pulse_in=pulse, fiber=fiber1, n_steps=St
 def dB(num):
     return 10 * np.log10(np.abs(num)**2)
 
-for y, AW, AT, pulse_out in results:
+for y, AW, AT, pulse_in, pulse_out in results:
     F = pulse_out.F_THz     # Frequency grid of pulse (THz)
     AW = AW.transpose()
     zW = dB(AW[:, (F > 0)] )
-    ax0.plot(F[F>0],    zW[0],  color = 'b')
+    ax0.plot(F[F>0],    zW[0],   color = 'b')
     ax0.plot(F[F>0],    zW[-1],  color = 'r')
     
 

--- a/src/examples/SSFM_coherence.py
+++ b/src/examples/SSFM_coherence.py
@@ -28,8 +28,8 @@ Steep   = True    # Enable self steepening?
 alpha = np.log((10**(Alpha * 0.1))) * 100  # convert from dB/cm to 1/m
 
 # select a method for include noise on the input pulse:
-# noise_type = 'sqrt_N_freq'
-noise_type = 'one_photon_freq'
+noise_type = 'sqrt_N_freq'
+# noise_type = 'one_photon_freq'
 
 
 # DRAFT - use these parameters for a quick calculation

--- a/src/pynlo/interactions/FourWaveMixing/SSFM.py
+++ b/src/pynlo/interactions/FourWaveMixing/SSFM.py
@@ -580,7 +580,7 @@ class SSFM:
         for num in range(0, num_trials):
 
             pulse = pulse_in.create_cloned_pulse()
-            pulse.add_noise(noise_type='one_photon_freq')
+            pulse.add_noise(noise_type=noise_type)
 
             y, AW, AT, pulse_out = self.propagate(pulse_in=pulse, fiber=fiber, n_steps=n_steps)
 

--- a/src/pynlo/interactions/FourWaveMixing/SSFM.py
+++ b/src/pynlo/interactions/FourWaveMixing/SSFM.py
@@ -584,11 +584,11 @@ class SSFM:
 
             y, AW, AT, pulse_out = self.propagate(pulse_in=pulse, fiber=fiber, n_steps=n_steps)
 
-            results.append((y, AW, AT, pulse_out))
+            results.append((y, AW, AT, pulse_in, pulse_out))
 
         
-        for n1, (y, E1, AT, pulseout) in enumerate(results):
-            for n2, (y, E2, AT, pulseout) in enumerate(results):
+        for n1, (y, E1, AT, pulsein, pulseout) in enumerate(results):
+            for n2, (y, E2, AT, pulsein, pulseout) in enumerate(results):
                 if n1 == n2: continue # don't compare the same trial
 
                 g12 = np.conj(E1)*E2/np.sqrt(np.abs(E1)**2 * np.abs(E2)**2)

--- a/src/pynlo/light/PulseBase.py
+++ b/src/pynlo/light/PulseBase.py
@@ -641,29 +641,28 @@ class Pulse:
         
         # This is all to get the number of photons/second in each frequency bin:
         size_of_bins = self.dF_mks                          # Bin width in [Hz]
-        power_per_bin = np.abs(self.AW)**2 * size_of_bins  # [W/Hz]  * [Hz]
+        power_per_bin = np.abs(self.AW)**2 / size_of_bins   # [J*Hz] / [Hz] = [J]
             
         h = constants.Planck # use scipy's constants package
         
         #photon_energy = h * self.W_THz/(2*np.pi) * 1e12
-        photon_energy = h * self.F_mks # h nu
+        photon_energy = h * self.F_mks # h nu [J]
         photons_per_bin = power_per_bin/photon_energy # photons / second
         photons_per_bin[photons_per_bin<0] = 0 # must be positive.
-        print np.sum(np.sqrt(photons_per_bin))
-        print photons_per_bin.shape
         
         # now generate some random intensity and phase arrays:
         size = np.shape(self.AW)[0]
-        random_intensity = np.random.normal(size=size)
-        random_phase = np.random.uniform(size=size) * 2 * np.pi
+        random_intensity = np.random.normal( size=size)
+        random_phase     = np.random.uniform(size=size) * 2 * np.pi
         
         if noise_type == 'sqrt_N_freq': # this adds Gausian noise with a sigma=sqrt(photons_per_bin)
+                                                                      # [J]         # [Hz]
             noise = random_intensity * np.sqrt(photons_per_bin) * photon_energy * size_of_bins * np.exp(1j*random_phase)
         
         elif noise_type == 'one_photon_freq': # this one photon per bin in the frequecy domain
             noise = random_intensity * photon_energy * size_of_bins * np.exp(1j*random_phase)
         else:
-            raise ValueError('noise_type not recognized. So far only sqrt_N_freq is supported')
+            raise ValueError('noise_type not recognized.')
         
         self.set_AW(self.AW + noise)
         

--- a/src/pynlo/light/PulseBase.py
+++ b/src/pynlo/light/PulseBase.py
@@ -658,10 +658,10 @@ class Pulse:
         random_phase = np.random.uniform(size=size) * 2 * np.pi
         
         if noise_type == 'sqrt_N_freq': # this adds Gausian noise with a sigma=sqrt(photons_per_bin)
-            noise = random_intensity * np.sqrt(photons_per_bin) * photon_energy * size_of_bins * 1e12 * np.exp(1j*random_phase)
+            noise = random_intensity * np.sqrt(photons_per_bin) * photon_energy * size_of_bins * np.exp(1j*random_phase)
         
         elif noise_type == 'one_photon_freq': # this one photon per bin in the frequecy domain
-            noise = random_intensity * photon_energy * size_of_bins * 1e12 * np.exp(1j*random_phase)
+            noise = random_intensity * photon_energy * size_of_bins * np.exp(1j*random_phase)
         else:
             raise ValueError('noise_type not recognized. So far only sqrt_N_freq is supported')
         
@@ -887,9 +887,9 @@ class Pulse:
         of the spectrogram in the context of supercontinuum generaiton. 
         (http://dx.doi.org/10.1103/RevModPhys.78.1135)
         
-        Alternatively, the gate_type can be set to 'frog', which performs a regular FROG measurement,
+        Alternatively, the gate_type can be set to 'frog', which simulates a SHG-FROG measurement,
         where the pulse is probed with a copy of itself, in an autocorrelation fashion.
-        Interpreting FROG spectrogram is less intuitive, so this is mainly useful for comparison
+        Interpreting this FROG spectrogram is less intuitive, so this is mainly useful for comparison
         with experimentally recorded FROG spectra (which are often easier to acquire than XFROG measurements.)
         
         A nice discussion of various FROG "species" is available here: http://frog.gatech.edu/tutorial.html


### PR DESCRIPTION
As discussed in https://github.com/pyNLO/PyNLO/pull/36#issuecomment-219893717, I think that we intended to remove the factor of `1e12` in the noise calculations on lines 661 and 664 of PulseBase.py. 

This PR addresses that, enables the calculate_coherence function to return the input pulse (which I've found useful), and modifies the SSFM_coherence example to accommodate this.

Cross referencing to our other discussion of noise/coherence in https://github.com/pyNLO/PyNLO/issues/22